### PR TITLE
add block to set walls on/off for all tiles of a kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+pxt_modules/

--- a/api.ts
+++ b/api.ts
@@ -255,7 +255,7 @@ namespace tileUtil {
     //% from.decompileIndirectFixedInstances=true
     //% to.shadow=tileset_tile_picker
     //% to.decompileIndirectFixedInstances=true
-    //% group="Tiles" weight=20
+    //% group="Tiles" weight=20 blockGap=8
     //% help=github:arcade-tile-util/docs/replace-all-tiles
     export function replaceAllTiles(from: Image, to: Image) {
         for (const loc of tiles.getTilesByType(from)) {

--- a/api.ts
+++ b/api.ts
@@ -264,6 +264,22 @@ namespace tileUtil {
     }
 
     /**
+     * Turns walls on or off for all tiles of a given kind.
+     */
+    //% block="set wall $on at all $tile locations"
+    //% blockId=tileUtil_setWalls
+    //% tile.shadow=tileset_tile_picker
+    //% tile.decompileIndirectFixedInstances=true
+    //% on.shadow=toggleOnOff
+    //% group="Tiles" weight=10
+    //% help=github:arcade-tile-util/docs/set-walls
+    export function setWalls(tile: Image, on: boolean) {
+        for (const loc of tiles.getTilesByType(tile)) {
+            tiles.setWallAt(loc, on);
+        }
+    }
+
+    /**
      * Returns the loaded tilemap.
      */
     //% block="current tilemap"

--- a/docs/set-walls.md
+++ b/docs/set-walls.md
@@ -1,0 +1,65 @@
+# set Walls
+
+Turn walls on or off for all tiles of a given kind.
+
+```sig
+tileUtil.setWalls(null, true)
+```
+
+## Parameters
+
+* **tile**: the image of the tile to set walls on
+* **on**: true to turn walls on and false to turn them off
+
+## Example
+
+This example turns on walls for all tiles of a given type when the `A` button is pressed.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    tileUtil.setWalls(assets.tile`myTile0`, true)
+})
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYzAwMGEwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```


### PR DESCRIPTION

![image](https://github.com/microsoft/arcade-tile-util/assets/13754588/a6f493d3-54e7-4e46-a926-bf17cd892d4e)


Adds a single block to this extension that lets you set walls on/off for all tiles with a given image. I have coded this roughly a million times on stream and we also have people asking for it on the forum:

https://forum.makecode.com/t/how-do-i-set-a-type-of-tile-to-be-always-a-wall/23680/2