### PR TITLE
Add tile getters and setters for tilemaps

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -280,6 +280,118 @@ namespace tileUtil {
     }
 
     /**
+     * Sets the tile at a given location in a tilemap
+     */
+    //% blockId=tileUtil_setTileAt
+    //% block="set $tile at $location in $tilemap"
+    //% tilemap.shadow=variables_get
+    //% tilemap.defl=myTilemap
+    //% location.shadow=mapgettile
+    //% tile.shadow=tileset_tile_picker
+    //% group=Tiles
+    //% weight=8
+    //% blockGap=8
+    //% help=github:arcade-tile-util/docs/set-tile-at
+    export function setTileAt(tilemap: tiles.TileMapData, location: tiles.Location, tile: Image) {
+        let index: number;
+
+        const tileset = tilemap.getTileset();
+        for (let i = 0; i < tileset.length; i++) {
+            if (tileset[i].equals(tile)) {
+                index = i;
+                break;
+            }
+        }
+
+        if (index === undefined) {
+            // not found; append to the tileset if there are spots left.
+            const newIndex = tileset.length;
+            if (newIndex < 0xff) {
+                tileset.push(tile);
+                index = newIndex;
+            }
+        }
+
+        if (index === undefined) {
+            throw "Too many tiles in tilemap";
+        }
+
+
+        tilemap.setTile(
+            location.column,
+            location.row,
+            index
+        );
+    }
+
+    /**
+     * Sets whether a wall is on or off at a given location in a tilemap.
+     */
+    //% blockId=tileUtil_setWallAt
+    //% block="set wall $on at $location in $tilemap"
+    //% tilemap.shadow=variables_get
+    //% tilemap.defl=myTilemap
+    //% location.shadow=mapgettile
+    //% tile.shadow=tileset_tile_picker
+    //% group=Tiles
+    //% weight=7
+    //% help=github:arcade-tile-util/docs/set-wall-at
+    export function setWallAt(tilemap: tiles.TileMapData, location: tiles.Location, on: boolean) {
+        tilemap.setWall(location.column, location.row, on);
+    }
+
+    /**
+     * Tests to see if the tile at a given location in a tilemap matches a given tile image.
+     */
+    //% blockId=tileUtil_tileIs
+    //% block="tile in $tilemap at $location is $tile"
+    //% tilemap.shadow=variables_get
+    //% tilemap.defl=myTilemap
+    //% location.shadow=mapgettile
+    //% tile.shadow=tileset_tile_picker
+    //% group=Tiles
+    //% weight=5
+    //% blockGap=8
+    //% help=github:arcade-tile-util/docs/tile-is
+    export function tileIs(tilemap: tiles.TileMapData, location: tiles.Location, tile: Image): boolean {
+        return tilemap.getTileImage(
+            tilemap.getTile(location.column, location.row)
+        ).equals(tile);
+    }
+
+    /**
+     * Tests to see if there is a wall at a given location in a tilemap.
+     */
+    //% blockId=tileUtil_tileIsWall
+    //% block="tile in $tilemap at $location is wall"
+    //% tilemap.shadow=variables_get
+    //% tilemap.defl=myTilemap
+    //% location.shadow=mapgettile
+    //% group=Tiles
+    //% weight=4
+    //% blockGap=8
+    //% help=github:arcade-tile-util/docs/tile-is-wall
+    export function tileIsWall(tilemap: tiles.TileMapData, location: tiles.Location): boolean {
+        return tilemap.isWall(location.column, location.row);
+    }
+
+
+    /**
+     * Gets the tile image in a tilemap at the given location
+     */
+    //% blockId=tileUtil_getTileImage
+    //% block="tile image in $tilemap at $location"
+    //% tilemap.shadow=variables_get
+    //% tilemap.defl=myTilemap
+    //% location.shadow=mapgettile
+    //% group=Tiles
+    //% weight=3
+    //% help=github:arcade-tile-util/docs/get-tile-image
+    export function getTileImage(tilemap: tiles.TileMapData, location: tiles.Location): Image {
+        return tilemap.getTileImage(tilemap.getTile(location.column, location.row));
+    }
+
+    /**
      * Returns the loaded tilemap.
      */
     //% block="current tilemap"

--- a/docs/get-tile-image.md
+++ b/docs/get-tile-image.md
@@ -1,0 +1,115 @@
+# Get Tile Image
+
+Gets the tile image at a location in a tilemap.
+
+```sig
+tileUtil.getTileImage(null, null)
+```
+
+## Parameters
+
+* **tilemap**: the tilemap to check the location in
+* **location**: the location to get the tile image from
+
+## Example
+
+Set a checkerboard tilemap with brown and white tiles into the game scene. When button `A` is pressed, chooses a random tile and spreads it to adjacent tiles
+
+```blocks
+let tileImage: Image;
+let location: tiles.Location;
+
+controller.A.onEvent(ControllerButtonEvent.Pressed, () => {
+    location = tiles.getTileLocation(
+        randint(
+            0,
+            tileUtil.tilemapProperty(
+                tileUtil.currentTilemap(),
+                tileUtil.TilemapProperty.Columns
+            ) - 1
+        ),
+        randint(
+            0,
+            tileUtil.tilemapProperty(
+                tileUtil.currentTilemap(),
+                tileUtil.TilemapProperty.Rows
+            ) - 1
+        )
+    )
+    tileImage = tileUtil.getTileImage(
+        tileUtil.currentTilemap(),
+        location
+    );
+
+    tileUtil.setTileAt(
+        tileUtil.currentTilemap(),
+        location.getNeighboringLocation(CollisionDirection.Left),
+        tileImage
+    )
+    tileUtil.setTileAt(
+        tileUtil.currentTilemap(),
+        location.getNeighboringLocation(CollisionDirection.Top),
+        tileImage
+    )
+    tileUtil.setTileAt(
+        tileUtil.currentTilemap(),
+        location.getNeighboringLocation(CollisionDirection.Right),
+        tileImage
+    )
+    tileUtil.setTileAt(
+        tileUtil.currentTilemap(),
+        location.getNeighboringLocation(CollisionDirection.Bottom),
+        tileImage
+    )
+})
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile3": {
+        "data": "hwQQABAAAAD//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////w==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYzAwMGEwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/docs/set-tile-at.md
+++ b/docs/set-tile-at.md
@@ -1,0 +1,77 @@
+# set Tile At
+
+Sets the tile at a given location in a tilemap.
+
+```sig
+tileUtil.setTileAt(null, null, null)
+```
+
+## Parameters
+
+* **tilemap**: the tilemap to set the tile in
+* **location**: the location to set the tile at
+* **tile**: the image of the tile to set
+
+## Example
+
+Set a checkerboard tilemap with brown and white tiles into the game scene. When button `A` is pressed, cover the white tiles with the blac tiles and cover the brown tiles with transparent tiles.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    if (index < 80) {
+        tileUtil.setTileAt(tileUtil.currentTilemap(), tiles.getTileLocation(index % 10, index / 10), assets.tile`myTile`)
+        index += 1
+    }
+})
+let index = 0
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile3": {
+        "data": "hwQQABAAAAD//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////w==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYzAwMGEwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/docs/set-wall-at.md
+++ b/docs/set-wall-at.md
@@ -1,0 +1,69 @@
+# set Wall At
+
+Sets whether a wall is on or off at a given location in a tilemap.
+
+
+```sig
+tileUtil.setWallAt(null, null, true)
+```
+
+## Parameters
+
+* **tilemap**: the tilemap to set the wall in
+* **location**: the location to set the wall at
+* **on**: whether or not the wall is on
+
+## Example
+
+This example turns on walls for all tiles of a given type when the `A` button is pressed.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    for (let value of tiles.getTilesByType(assets.tile`myTile0`)) {
+        tileUtil.setWallAt(tileUtil.currentTilemap(), value, true);
+    }
+})
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYzAwMGEwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/docs/tile-is-wall.md
+++ b/docs/tile-is-wall.md
@@ -1,0 +1,77 @@
+# Tile is Wall
+
+Checks the tile at a given location in a tilemap to see if it is a wall
+
+```sig
+tileUtil.tileIsWall(null, null)
+```
+
+## Parameters
+
+* **tilemap**: the tilemap to check the location in
+* **location**: the location to check
+
+## Example
+
+This example inverts all of the walls in tilemap when `A` is pressed
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    for (let indexX = 0; indexX <= tileUtil.tilemapProperty(tileUtil.currentTilemap(), tileUtil.TilemapProperty.Columns) - 1; indexX++) {
+        for (let indexY = 0; indexY <= tileUtil.tilemapProperty(tileUtil.currentTilemap(), tileUtil.TilemapProperty.Rows) - 1; indexY++) {
+            tileUtil.setWallAt(tileUtil.currentTilemap(), tiles.getTileLocation(indexX, indexY), !tileUtil.tileIsWall(tileUtil.currentTilemap(), tiles.getTileLocation(indexX, indexY)))
+        }
+    }
+
+})
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile3": {
+        "data": "hwQQABAAAAD//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////w==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYzAwMGEwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/docs/tile-is.md
+++ b/docs/tile-is.md
@@ -1,0 +1,80 @@
+# Tile is
+
+Checks the tile at a given location in a tilemap to see if it matches an image.
+
+```sig
+tileUtil.tileIs(null, null, null)
+```
+
+## Parameters
+
+* **tilemap**: the tilemap to check the location in
+* **location**: the location to check
+* **tile**: the image of the tile to check for
+
+## Example
+
+Set a checkerboard tilemap with brown and white tiles into the game scene. When button `A` is pressed, replaces all the tiles of one type with another.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    for (let indexX = 0; indexX <= tileUtil.tilemapProperty(tileUtil.currentTilemap(), tileUtil.TilemapProperty.Columns) - 1; indexX++) {
+        for (let indexY = 0; indexY <= tileUtil.tilemapProperty(tileUtil.currentTilemap(), tileUtil.TilemapProperty.Rows) - 1; indexY++) {
+            if (tileUtil.tileIs(tileUtil.currentTilemap(), tiles.getTileLocation(indexX, indexY), assets.tile`myTile1`)) {
+                tileUtil.setTileAt(tileUtil.currentTilemap(), tiles.getTileLocation(indexX, indexY), assets.tile`myTile2`)
+            }
+        }
+    }
+
+})
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREREQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile3": {
+        "data": "hwQQABAAAAD//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////w==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYzAwMGEwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDEwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```


### PR DESCRIPTION
Adds these blocks:

![image](https://github.com/microsoft/arcade-tile-util/assets/13754588/c8999ba5-0188-4182-ad8c-db5ca36edad9)

We currently don't have a way to get/set tiles and walls in tilemaps assigned in variables