### PR TITLE
Adding block for looping over all the tiles in a tilemap

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -334,4 +334,25 @@ namespace tileUtil {
             for (const cb of createdHandlers) cb.handler(sprite)
         }
     }
+
+    /**
+     * Loops over each tile in a tilemap and runs the nested code
+     *
+     * @param tilemap The tilemap to loop over
+     * @param handler The code to run
+     */
+    //% blockId=tileUtil_forEachTileInMap
+    //% block="for each tile in $tilemap with $column $row $location"
+    //% tilemap.shadow=tileUtil_getLoadedMap
+    //% handlerStatement
+    //% draggableParameters="reporter"
+    //% group=Tiles
+    //% weight=0
+    export function forEachTileInMap(tilemap: tiles.TileMapData, handler: (column: number, row: number, location: tiles.Location) => void) {
+        for (let c = 0; c < tilemap.width; c++) {
+            for (let r = 0; r < tilemap.height; r++) {
+                handler(c, r, new tiles.Location(c, r, null));
+            }
+        }
+    }
 }

--- a/api.ts
+++ b/api.ts
@@ -348,6 +348,7 @@ namespace tileUtil {
     //% draggableParameters="reporter"
     //% group=Tiles
     //% weight=0
+    //% help=github:arcade-tile-util/docs/for-each-tile-in-map
     export function forEachTileInMap(tilemap: tiles.TileMapData, handler: (column: number, row: number, location: tiles.Location) => void) {
         for (let c = 0; c < tilemap.width; c++) {
             for (let r = 0; r < tilemap.height; r++) {

--- a/docs/for-each-tile-in-map.md
+++ b/docs/for-each-tile-in-map.md
@@ -1,0 +1,94 @@
+# for each Tile in Map
+
+Loops over every location in a tilemap and runs some code at each tile.
+
+```sig
+tileUtil.forEachTileInMap(tileUtil.currentTilemap(), function (column, row, location) {
+})
+```
+
+## Parameters
+
+* **tileMap**: the tilemap to loop over.
+* **column**: the column of the current location in the map.
+* **row**: the row of the current location in the map.
+* **location**: the current location in the map.
+
+## Example
+
+This example takes a simple tilemap where the walls are marked with a single tile and automatically fills in the appropriate wall tile for each location based on the surrounding tiles
+
+```blocks
+tiles.setCurrentTilemap(tilemap`level1`)
+tileUtil.setWalls(assets.tile`myTile`, true)
+tileUtil.forEachTileInMap(tileUtil.currentTilemap(), function (column, row, location) {
+    if (tiles.tileAtLocationIsWall(location)) {
+        if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column + 1, row)))) {
+            if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column, row + 1)))) {
+                tiles.setTileAt(location, sprites.dungeon.purpleInnerSouthEast)
+            } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column, row - 1)))) {
+                tiles.setTileAt(location, sprites.dungeon.purpleInnerNorthEast)
+            } else {
+                tiles.setTileAt(location, sprites.dungeon.purpleOuterWest0)
+            }
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column - 1, row)))) {
+            if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column, row + 1)))) {
+                tiles.setTileAt(location, sprites.dungeon.purpleInnerSouthWest)
+            } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column, row - 1)))) {
+                tiles.setTileAt(location, sprites.dungeon.purpleInnerNorthWest)
+            } else {
+                tiles.setTileAt(location, sprites.dungeon.purpleOuterEast1)
+            }
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column, row + 1)))) {
+            tiles.setTileAt(location, sprites.dungeon.purpleOuterNorth0)
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column, row - 1)))) {
+            tiles.setTileAt(location, sprites.dungeon.purpleOuterSouth1)
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column + 1, row + 1)))) {
+            tiles.setTileAt(location, sprites.dungeon.purpleOuterNorthWest)
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column + 1, row - 1)))) {
+            tiles.setTileAt(location, sprites.dungeon.purpleOuterSouthEast)
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column - 1, row + 1)))) {
+            tiles.setTileAt(location, sprites.dungeon.purpleOuterNorthEast)
+        } else if (!(tiles.tileAtLocationIsWall(tiles.getTileLocation(column - 1, row - 1)))) {
+            tiles.setTileAt(location, sprites.dungeon.purpleOuterSouthWest)
+        }
+    }
+})
+
+```
+
+```package
+arcade-tile-util=github:microsoft/arcade-tile-util
+```
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABmZmZmZmZmZmZmERFhZmZmZmZmZmFmZmZmZmYWYWZmZmZmZmZhZmZmZmYREWFmZmZmZmZmZmZmZmZmZhFhZmZmZmZmYWFmZmZmZmYRYWZmZmZmZmZhZmZmZmZmZmZmZmZmZhERYWZmZmZmZmZmZmZmZmYREWFmZmZmZmZmZmZmZg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDIwMjAxMDEwMTAxMDEwMjAyMDIwMjAyMDIwMjAyMDEwMTAyMDIwMjAyMDIwMjAyMDIwMTAyMDIwMjAyMDEwMTAyMDIwMjAyMDIwMjAyMDIwMTAxMDIwMjAyMDIwMTAyMDIwMjAyMDIwMjAyMDIwMTAxMDIwMjAyMDIwMjAyMDIwMjAxMDEwMTAxMDEwMjAyMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "sprites.dungeon.floorLight0"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```


### PR DESCRIPTION
![image](https://github.com/microsoft/arcade-tile-util/assets/13754588/37d8787b-acae-4bf8-88e6-1b64de08eb73)

Adds a block for looping over all locations in a tilemap.

This is an exceedingly tedious task in blocks currently. The process looks like this:
1. Drag out two for-index loops and nest them
2. Create two variables (e.g. column and row)
3. Right click on the index variable of each for-loop and select column/row (most people don't even know you can do this)
4. For the upper bound of each loop, drag out the "tilemap width" block
5. For the upper bound of each loop, drag out a subtraction block so that you can subtract 1 (our loops are inclusive)

Now it's just one block! Hurrah!